### PR TITLE
chore: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1.8.0
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         with:
           app_id: ${{ secrets.ADD_TO_PROJECT_APP_ID }}
           private_key: ${{ secrets.GASTOGITHUB_PRIVATE_KEY }}
 
       # https://github.com/marketplace/actions/add-to-github-projects
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85 # v0.4.0
         id: addItem
         with:
           project-url: https://github.com/orgs/Tech-Design-Inc/projects/4

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -13,15 +13,15 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: git fetch
         run: |
           git fetch origin main
 
       - name: Assign a reviewer
-        uses: necojackarc/auto-request-review@v0.10.0
+        uses: necojackarc/auto-request-review@5f91f424cabb3211c669e49e79da8363f7df395b # v0.10.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/templates/reviewers.yml
 
-      - uses: toshimaru/auto-author-assign@v2.0.0
+      - uses: toshimaru/auto-author-assign@293cfe93d5edcadd7354d954519f3bb441d9d695 # v2.0.0

--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -9,9 +9,9 @@ jobs:
   create-pull-request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Create Pull Request
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
         with:
           destination_branch: "main"
           pr_title: "Auto-generated pull request triggered by ${{ github.actor }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: TimonVS/pr-labeler-action@v4.1.1
+      - uses: TimonVS/pr-labeler-action@8b99f404a073744885d8021d1de4e40c6eaf38e2 # v4.1.1
         with:
           configuration-path: .github/templates/pr-labeler-for-dev-type.yml # optional, .github/pr-labeler.yml is the default value
         env:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
         with:
           configuration-path: .github/templates/pr-labeler-for-dev-component.yml # optional, .github/pr-labeler.yml is the default value
         env:


### PR DESCRIPTION
# OVERVIEW / 概要

**WHAT**:
- SHA pinning ポリシーを有効化するため、GitHub Actions の参照をフルコミット SHA に固定しました
- [pinact](https://github.com/suzuki-shunsuke/pinact) でサードパーティ Action を pin（`# vX.Y.Z` コメント付き）
- アクティブなワークフローの動作に変更はありません（参照先 SHA は固定前のタグと同一コミット）

**ISSUE LINK**:
- https://app.asana.com/1/1206449769608030/project/1207141005647766/task/1214827664359143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
